### PR TITLE
allow file patching for HCs if -filePatching

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -20,7 +20,7 @@ var defaultPlatform = function () {
 var Server = function (options) {
   this.options = _.defaults(options, {
     admins: null,
-    allowedFilePatching: null,
+    allowedFilePatching: options.filePatching ? 1 : null,
     allowedHTMLLoadExtensions: null,
     allowedLoadFileExtensions: null,
     allowedPreprocessFileExtensions: null,


### PR DESCRIPTION
If we don't allow file patching for HCs (that inherit the -filePatching flag from their parent) they're gonna have a bad time connecting.